### PR TITLE
Fix overall progress indicator and harmonize error colors of error logs

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -102,7 +102,10 @@ impl MultiRepoHistory {
             .collect();
 
         commits.sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp).reverse());
-        Ok(MultiRepoHistory { repos, commits })
+        Ok(MultiRepoHistory {
+            repos,
+            commits,
+        })
     }
 }
 
@@ -195,11 +198,9 @@ impl RepoCommit {
             None
         };
         let b = commit.tree().expect("Failed to open commit");
-        let lines = match git_repo.diff_tree_to_tree(a.as_ref(), Some(&b), None) {
-            Ok(diff) => Self::diff_to_vec(diff),
-            Err(_) => Vec::new(),
-        };
-        lines
+        git_repo.diff_tree_to_tree(a.as_ref(), Some(&b), None)
+            .map(Self::diff_to_vec)
+            .unwrap_or_default()
     }
 
     fn diff_to_vec(diff: Diff<'_>) -> Vec<(char, String)> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -45,16 +45,15 @@ impl MultiRepoHistory {
 
         let mut commits: Vec<RepoCommit> = repos
             .par_iter()
-            .progress_with(overall_progress)
-            .filter_map(move |repo| {
+            .map(move |repo| {
                 let progress_bar = &progress_bars[rayon::current_thread_index()?];
                 progress_bar.set_message(&format!("Scanning {}", repo.rel_path));
 
                 let progress_error = |msg: &str, error: &dyn std::error::Error| {
                     progress_bar.println(format!(
                         "{}: {}: {}",
-                        style(&repo.rel_path).cyan(),
                         style(&msg).red(),
+                        style(&repo.rel_path).blue(),
                         error
                     ));
                     progress_bar.inc(1);
@@ -80,7 +79,7 @@ impl MultiRepoHistory {
                 for commit_id in revwalk {
                     let commit = commit_id
                         .and_then(|commit_id| git_repo.find_commit(commit_id))
-                        .map_err(|e| progress_error("Failed find commit", &e))
+                        .map_err(|e| progress_error("Failed to find commit", &e))
                         .ok()?;
                     let (include, abort) = classifier.classify(&commit);
                     if include {
@@ -91,16 +90,19 @@ impl MultiRepoHistory {
                     }
                 }
                 progress_bar.set_message("Idle");
-                Some(commits)
+                if commits.is_empty() {
+                    None
+                } else {
+                    Some(commits)
+                }
             })
+            .progress_with(overall_progress)
+            .filter_map(|x| x)
             .flatten()
             .collect();
 
         commits.sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp).reverse());
-        Ok(MultiRepoHistory {
-            repos,
-            commits,
-        })
+        Ok(MultiRepoHistory { repos, commits })
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -104,6 +104,8 @@ pub fn show(model: MultiRepoHistory) {
         diff_view.on_event(Event::Key(Key::Down));
     });
 
-    first_commit.map(|commit| update(&mut siv, 0, commits, &commit));
+    if let Some(commit) = first_commit {
+        update(&mut siv, 0, commits, &commit)
+    }
     siv.run();
 }

--- a/src/views/table_view.rs
+++ b/src/views/table_view.rs
@@ -74,7 +74,6 @@ type IndexCallback = Rc<dyn Fn(&mut Cursive, usize, usize)>;
 /// # use std::cmp::Ordering;
 /// # use cursive_table_view::{TableView, TableViewItem};
 /// # use cursive::align::HAlign;
-/// # fn main() {
 /// // Provide a type for the table's columns
 /// #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 /// enum BasicColumn {
@@ -119,7 +118,6 @@ type IndexCallback = Rc<dyn Fn(&mut Cursive, usize, usize)>;
 ///                          c.ordering(Ordering::Greater).align(HAlign::Right).width(20)
 ///                      })
 ///                      .default_column(BasicColumn::Name);
-/// # }
 /// ```
 pub struct TableView<T: TableViewItem<H>, H: Eq + Hash + Copy + Clone + 'static> {
     enabled: bool,


### PR DESCRIPTION
The overall progress was incremented at the beginning of a repo
scan - moved to the finalization. Furthermore this contains a small
optimization in the commit collection and a adjustment of the error
logs.

+ clippy fixes